### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -17,15 +17,15 @@ Timer0	KEYWORD1
 # Methods and Functions (KEYWORD2)
 ###########################################
 
-begin KEYWORD2
-print KEYWORD2
-available KEYWORD2
-get KEYWORD2
-set KEYWORD2
-clear KEYWORD2
-read KEYWORD2
-write KEYWORD2
-start KEYWORD2
-stop KEYWORD2
-onTick KEYWORD2
-refresh KEYWORD2
+begin	KEYWORD2
+print	KEYWORD2
+available	KEYWORD2
+get	KEYWORD2
+set	KEYWORD2
+clear	KEYWORD2
+read	KEYWORD2
+write	KEYWORD2
+start	KEYWORD2
+stop	KEYWORD2
+onTick	KEYWORD2
+refresh	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference: https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords